### PR TITLE
Update ColorfulConferrerRZ.swift

### DIFF
--- a/RZColorfulSwift/Classes/AttributeCore/ColorfulConferrerRZ.swift
+++ b/RZColorfulSwift/Classes/AttributeCore/ColorfulConferrerRZ.swift
@@ -17,7 +17,7 @@ public class ColorfulConferrerRZ {
         let text = NSMutableAttributedString.init()
         texts.forEach { (t) in
             if let t = t as? AttributePackageRZ, let tt = t.package(_paragraphStyle?.paragraph, _shadow?.shadow) {
-                if let p = tt.attribute(.paragraphStyle, at:0, effectiveRange: nil) as? RZMutableParagraphStyle, p.numberOfLines > 0, p.textDrawMaxWidth > 0 {
+                if tt.length > 0, let p = tt.attribute(.paragraphStyle, at:0, effectiveRange: nil) as? RZMutableParagraphStyle, p.numberOfLines > 0, p.textDrawMaxWidth > 0 {
                     /// 默认占位符 ... 也可以自定义
                     let placeholder : NSAttributedString = p.truncateText ?? tt.rz.copyAttributeToText("...")
                     let mode = p.lineBreakMode


### PR DESCRIPTION
通过
``
textView.attributedText.rz.codingToHtmlWithImagesURLSIfHad(urls: images) ``
获取 html 文本，如果 textView 内没有填写任何数据，会返回：

<（我是防止转义）!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n<html>\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n<meta http-equiv=\"Content-Style-Type\" content=\"text/css\">\n<title></title>\n<meta name=\"Generator\" content=\"Cocoa HTML Writer\">\n\n</head>\n<body>\n</body>\n</html（我是防止转义）>\n

然后当要把这段内容恢复到 textView 内时（如下代码），会出现崩溃情况，报错信息为 Out of bound，断点走下去发现是在代码修改处发生的，如果 tt 为空，直接用下标为 0 的，则会发生越界情况，所以需要先加上一个判断。

``
textView.rz.colorfulConfer { confer in
    confer.htmlString(html)
}
``